### PR TITLE
fix error <path/a.bib> <path/b.bib> are the same file on open URL

### DIFF
--- a/org-ref-utils.el
+++ b/org-ref-utils.el
@@ -305,7 +305,7 @@ in a directory. Optional PREFIX argument toggles between
 (defun org-ref-open-url-at-point ()
   "Open the url for bibtex key under point."
   (interactive)
-  (let* ((bibtex-completion-bibliography (org-ref-find-bibliography))
+  (let* ((bibtex-completion-bibliography (file-truename (car (org-ref-find-bibliography))))
 	 (results (org-ref-get-bibtex-key-and-file))
          (key (car results))
          (bibfile (cdr results)))


### PR DESCRIPTION
(org-ref-find-bibliography) can return path from config variable, which may contain symbolic links in the path, when it is compared with (org-ref-get-bibtex-key-and-file), which uses (buffer-file-name) to retrieve a bib file path, it returns an absolute path with all symbolic links resolved. Two different paths pointing to the same file leads to the above error and prevents the body of the let clause from executing. Using the file-truename prevents this error.